### PR TITLE
Remove MLflow version 

### DIFF
--- a/8-MLflow-visualization/README.md
+++ b/8-MLflow-visualization/README.md
@@ -3,7 +3,7 @@
 > [!NOTE]  
 > If you wish to run the included examples on LUMI, have a look at the [quickstart](https://github.com/Lumi-supercomputer/LUMI-AI-Guide/tree/main/1-quickstart#readme) chapter for instructions on how to set up the required environment.
 
-[MLflow](https://www.mlflow.org/) is an open source tool for tracking experiments and models in machine learning projects. MLflow can be easily installed with `pip install mlflow==2.22.*` (currently, LUMI webinterface requires `mlflow==2.22.*` to read the created file). Adapting your code to use MLflow requires minimal modification, and the results can be easily displayed using the web interface.
+__[MLflow](https://www.mlflow.org/)__ is an open source tool for tracking experiments and models in machine learning projects. MLflow 3.11.1 is already available in the PyTorch container. Adapting your code to use MLflow requires minimal modification, and the results can be easily displayed using the web interface.
 
 ## Collecting logs
 

--- a/8-MLflow-visualization/README.md
+++ b/8-MLflow-visualization/README.md
@@ -3,7 +3,7 @@
 > [!NOTE]  
 > If you wish to run the included examples on LUMI, have a look at the [quickstart](https://github.com/Lumi-supercomputer/LUMI-AI-Guide/tree/main/1-quickstart#readme) chapter for instructions on how to set up the required environment.
 
-__[MLflow](https://www.mlflow.org/)__ is an open source tool for tracking experiments and models in machine learning projects. MLflow 3.11.1 is already available in the PyTorch container. Adapting your code to use MLflow requires minimal modification, and the results can be easily displayed using the web interface.
+__[MLflow](https://www.mlflow.org/)__ is an open source tool for tracking experiments and models in machine learning projects. MLflow 3.11.1 is already available in the lumi-multitorch-full container as of the April 2026 release (ROCm 7.0) and later. Adapting your code to use MLflow requires minimal modification, and the results can be easily displayed using the web interface.
 
 ## Collecting logs
 

--- a/8-MLflow-visualization/run_ddp_torchrun.sh
+++ b/8-MLflow-visualization/run_ddp_torchrun.sh
@@ -22,10 +22,5 @@ export MIOPEN_USER_DB=$MIOPEN_DIR/config
 # choose container
 SIF=/appl/local/laifs/containers/lumi-multitorch-u24r70f21m50t210-20260415_130625/lumi-multitorch-full-u24r70f21m50t210-20260415_130625.sif
 
-# Tell RCCL to use Slingshot interfaces and GPU RDMA
-export NCCL_SOCKET_IFNAME=hsn0,hsn1,hsn2,hsn3
-export NCCL_NET_GDR_LEVEL=PHB
-
-export SINGULARITYENV_PREPEND_PATH=/user-software/bin # gives access to packages inside the container
 
 srun singularity run $SIF bash -c 'python -m torch.distributed.run --standalone --nnodes=1 --nproc_per_node=8 mlflow_ddp_visiontransformer.py'

--- a/8-MLflow-visualization/run_ddp_torchrun.sh
+++ b/8-MLflow-visualization/run_ddp_torchrun.sh
@@ -29,4 +29,4 @@ export NCCL_NET_GDR_LEVEL=PHB
 export SINGULARITYENV_PREPEND_PATH=/user-software/bin # gives access to packages inside the container
 
 # need to create sqsh file with mlflow included
-srun singularity run -B ../resources/ai-guide-env.sqsh:/user-software:image-src=/ $SIF bash -c 'python -m torch.distributed.run --standalone --nnodes=1 --nproc_per_node=8 mlflow_ddp_visiontransformer.py'
+srun singularity run $SIF bash -c 'python -m torch.distributed.run --standalone --nnodes=1 --nproc_per_node=8 mlflow_ddp_visiontransformer.py'

--- a/8-MLflow-visualization/run_ddp_torchrun.sh
+++ b/8-MLflow-visualization/run_ddp_torchrun.sh
@@ -20,7 +20,7 @@ export MIOPEN_CUSTOM_CACHE_DIR=$MIOPEN_DIR/cache
 export MIOPEN_USER_DB=$MIOPEN_DIR/config
 
 # choose container
-SIF=/appl/local/laifs/containers/lumi-multitorch-u24r64f21m43t29-20260225_144743/lumi-multitorch-full-u24r64f21m43t29-20260225_144743.sif
+SIF=/appl/local/laifs/containers/lumi-multitorch-u24r70f21m50t210-20260415_130625/lumi-multitorch-full-u24r70f21m50t210-20260415_130625.sif
 
 # Tell RCCL to use Slingshot interfaces and GPU RDMA
 export NCCL_SOCKET_IFNAME=hsn0,hsn1,hsn2,hsn3

--- a/8-MLflow-visualization/run_ddp_torchrun.sh
+++ b/8-MLflow-visualization/run_ddp_torchrun.sh
@@ -28,5 +28,4 @@ export NCCL_NET_GDR_LEVEL=PHB
 
 export SINGULARITYENV_PREPEND_PATH=/user-software/bin # gives access to packages inside the container
 
-# need to create sqsh file with mlflow included
 srun singularity run $SIF bash -c 'python -m torch.distributed.run --standalone --nnodes=1 --nproc_per_node=8 mlflow_ddp_visiontransformer.py'

--- a/resources/requirements.txt
+++ b/resources/requirements.txt
@@ -1,2 +1,1 @@
 h5py
-mlflow==2.22.* # required only for part 8


### PR DESCRIPTION
Fixes #87 

MLflow 3.11.1 is now available in the PyTorch container, so the version-specific installation hint is no longer needed. This PR removes the note that restricted users to mlflow==2.22.* and simplifies the install command to pip install mlflow.

Note: OOD now also has its own MLflow installation with versions 2.22.0 and 3.11.1 available.