### PR TITLE
feat: update to ROCm 7.0 PyTorch container

### DIFF
--- a/1-quickstart/README.md
+++ b/1-quickstart/README.md
@@ -16,7 +16,7 @@ Next, navigate to the `LUMI-AI-Guide/quickstart` directory:
 cd LUMI-AI-Guide/1-quickstart
 ```
 
-We now need to setup the environment if we wish to run the included python scripts. We will use one of the provided PyTorch containers that we extend with additional packages (this step will be explained in more detail in the next chapter [Setting up your own environment](../2-setting-up-environment/README.md)). The fastest way to achieve this is to use the provided script `set_up_environment.sh`:
+We now need to setup the environment if we wish to run the included python scripts. We will use one of the provided PyTorch containers. The fastest way to achieve this is to use the provided script `set_up_environment.sh`:
 
 ```bash
 ./set_up_environment.sh
@@ -28,7 +28,7 @@ If you receive a permission denied error, you can make the script executable by 
 chmod +x set_up_environment.sh
 ```
 
-After the script has finished, you will see now two new files in the `LUMI-AI-Guide/resources/` directory. One is the training dataset in a `hdf5` file format (`train_images.hdf5`). The other one is the virtual python enviroment in a `sqfs` file format (`ai-guide-env.sqsh`).
+After the script has finished, you will see now one new file in the `LUMI-AI-Guide/resources/` directory. It is the training dataset in a `hdf5` file format (`train_images.hdf5`).
 
 For this example, we use the [Tiny ImageNet Dataset](https://paperswithcode.com/dataset/tiny-imagenet) which is already transformed into the file system friendly hdf5 format (Chapter [File formats for training data](../3-file-formats/README.md) explains in detail why this step is necessary). Please have a look at the terms of access for the ImageNet Dataset [here](https://www.image-net.org/download.php).
 

--- a/1-quickstart/run.sh
+++ b/1-quickstart/run.sh
@@ -18,7 +18,6 @@ export MIOPEN_CUSTOM_CACHE_DIR=$MIOPEN_DIR/cache
 export MIOPEN_USER_DB=$MIOPEN_DIR/config
 
 # choose container
-SIF=/appl/local/laifs/containers/lumi-multitorch-u24r64f21m43t29-20260225_144743/lumi-multitorch-full-u24r64f21m43t29-20260225_144743.sif
+SIF=/appl/local/laifs/containers/lumi-multitorch-u24r70f21m50t210-20260415_130625/lumi-multitorch-full-u24r70f21m50t210-20260415_130625.sif
 
-export SINGULARITYENV_PREPEND_PATH=/user-software/bin # gives access to packages inside the container
-singularity run -B ../resources/ai-guide-env.sqsh:/user-software:image-src=/ $SIF bash -c 'python visiontransformer.py'
+singularity run $SIF bash -c 'python visiontransformer.py'

--- a/1-quickstart/run.sh
+++ b/1-quickstart/run.sh
@@ -17,6 +17,11 @@ MIOPEN_DIR=$(mktemp -d)
 export MIOPEN_CUSTOM_CACHE_DIR=$MIOPEN_DIR/cache
 export MIOPEN_USER_DB=$MIOPEN_DIR/config
 
+# Set your huggingface cache to scratch to avoid saving to home directory
+# See https://huggingface.co/docs/huggingface_hub/en/package_reference/environment_variables
+export HF_HUB_CACHE="/scratch/${SLURM_JOB_ACCOUNT}/${USER}/hfcache"
+mkdir -p "$HF_HUB_CACHE"
+
 # choose container
 SIF=/appl/local/laifs/containers/lumi-multitorch-u24r70f21m50t210-20260415_130625/lumi-multitorch-full-u24r70f21m50t210-20260415_130625.sif
 

--- a/1-quickstart/run.sh
+++ b/1-quickstart/run.sh
@@ -17,10 +17,10 @@ MIOPEN_DIR=$(mktemp -d)
 export MIOPEN_CUSTOM_CACHE_DIR=$MIOPEN_DIR/cache
 export MIOPEN_USER_DB=$MIOPEN_DIR/config
 
-# Set your huggingface cache to scratch to avoid saving to home directory
-# See https://huggingface.co/docs/huggingface_hub/en/package_reference/environment_variables
-export HF_HUB_CACHE="/scratch/${SLURM_JOB_ACCOUNT}/${USER}/hfcache"
-mkdir -p "$HF_HUB_CACHE"
+# Set your TORCH_HOME cache to scratch to avoid saving to home directory
+# https://docs.pytorch.org/docs/2.11/hub.html#where-are-my-downloaded-models-saved
+export TORCH_HOME="/scratch/${SLURM_JOB_ACCOUNT}/${USER}/torch_home"
+mkdir -p "$TORCH_HOME"
 
 # choose container
 SIF=/appl/local/laifs/containers/lumi-multitorch-u24r70f21m50t210-20260415_130625/lumi-multitorch-full-u24r70f21m50t210-20260415_130625.sif

--- a/1-quickstart/set_up_environment.sh
+++ b/1-quickstart/set_up_environment.sh
@@ -3,5 +3,3 @@
 # Please have a look at the terms of access (https://www.image-net.org/download.php) before using the dataset
 echo "Copying training data to ../resources/ directory."
 cp /appl/local/training/LUMI-AI-Guide/tiny-imagenet-dataset.hdf5 ../resources/train_images.hdf5
-echo "Copying sqsh virtual environment to ../resources/ directory."
-cp /appl/local/training/LUMI-AI-Guide/ai-guide-env.sqsh ../resources/ai-guide-env.sqsh

--- a/4-data-storage/run_ramfs.sh
+++ b/4-data-storage/run_ramfs.sh
@@ -18,13 +18,10 @@ export MIOPEN_CUSTOM_CACHE_DIR=$MIOPEN_DIR/cache
 export MIOPEN_USER_DB=$MIOPEN_DIR/config
 
 # choose container
-SIF=/appl/local/laifs/containers/lumi-multitorch-u24r64f21m43t29-20260225_144743/lumi-multitorch-full-u24r64f21m43t29-20260225_144743.sif
-
-# add path to additional packages in squasfs file
-export SINGULARITYENV_PREPEND_PATH=/user-software/bin
+SIF=/appl/local/laifs/containers/lumi-multitorch-u24r70f21m50t210-20260415_130625/lumi-multitorch-full-u24r70f21m50t210-20260415_130625.sif
 
 # run python script inside container 
-srun singularity run -B ../resources/ai-guide-env.sqsh:/user-software:image-src=/ $SIF bash -c '
+srun singularity run $SIF bash -c '
   echo "Copying training data to /tmp/";
   time cp -a ../resources/train_images.hdf5 /tmp/. ;
   echo "Running training";

--- a/4-data-storage/run_ramfs.sh
+++ b/4-data-storage/run_ramfs.sh
@@ -17,6 +17,11 @@ MIOPEN_DIR=$(mktemp -d)
 export MIOPEN_CUSTOM_CACHE_DIR=$MIOPEN_DIR/cache
 export MIOPEN_USER_DB=$MIOPEN_DIR/config
 
+# Set your huggingface cache to scratch to avoid saving to home directory
+# See https://huggingface.co/docs/huggingface_hub/en/package_reference/environment_variables
+export HF_HUB_CACHE="/scratch/${SLURM_JOB_ACCOUNT}/${USER}/hfcache"
+mkdir -p "$HF_HUB_CACHE"
+
 # choose container
 SIF=/appl/local/laifs/containers/lumi-multitorch-u24r70f21m50t210-20260415_130625/lumi-multitorch-full-u24r70f21m50t210-20260415_130625.sif
 

--- a/4-data-storage/run_ramfs.sh
+++ b/4-data-storage/run_ramfs.sh
@@ -17,10 +17,10 @@ MIOPEN_DIR=$(mktemp -d)
 export MIOPEN_CUSTOM_CACHE_DIR=$MIOPEN_DIR/cache
 export MIOPEN_USER_DB=$MIOPEN_DIR/config
 
-# Set your huggingface cache to scratch to avoid saving to home directory
-# See https://huggingface.co/docs/huggingface_hub/en/package_reference/environment_variables
-export HF_HUB_CACHE="/scratch/${SLURM_JOB_ACCOUNT}/${USER}/hfcache"
-mkdir -p "$HF_HUB_CACHE"
+# Set your TORCH_HOME cache to scratch to avoid saving to home directory
+# https://docs.pytorch.org/docs/2.11/hub.html#where-are-my-downloaded-models-saved
+export TORCH_HOME="/scratch/${SLURM_JOB_ACCOUNT}/${USER}/torch_home"
+mkdir -p "$TORCH_HOME"
 
 # choose container
 SIF=/appl/local/laifs/containers/lumi-multitorch-u24r70f21m50t210-20260415_130625/lumi-multitorch-full-u24r70f21m50t210-20260415_130625.sif

--- a/5-multi-gpu-and-node/README.md
+++ b/5-multi-gpu-and-node/README.md
@@ -325,21 +325,6 @@ srun --cpu-bind=mask_cpu=$CPU_BIND_MASKS,v singularity exec ...
 Since the bindings are not set in the python script but in the job submissions script, this is a more portable solution than what can be achieved with the torchrun launcher.
 
 
-### RCCL environment variables
-In all job scripts, two environment variables should be set to make sure that [RCCL](https://rocm.docs.amd.com/projects/rccl/en/latest/) uses the correct interfaces:
-
-```bash
-# To have RCCL use the Slingshot interfaces:
-export NCCL_SOCKET_IFNAME=hsn0,hsn1,hsn2,hsn3
-
-# To have RCCL use GPU RDMA:
-export NCCL_NET_GDR_LEVEL=PHB
-```
-
-On a LUMI-G node, each GPU is connected to a 200Gb/s Network Interface Card (NIC) (see also https://docs.lumi-supercomputer.eu/hardware/lumig/). To make use of this connection, the environment variable `NCCL_NET_GDR_LEVEL` needs to be set to `PHB`. This variable determines the maximum distance between the NIC and the GPU for which GPU Direct RDMA is used. If this variable is set incorrectly, this could result in slower communication between GPUs on different nodes. Note that from ROCm 6.2 onwards, `PHB` is the default value of `NCCL_NET_GDR_LEVEL`.
-
-`NCCL_SOCKET_IFNAME` must be set to make RCCL use the Slingshot-11 interconnect to which each GPU is connected. If this is not set, RCCL will try to use a network interface that it has no access to and inter-node GPU-to-GPU communication will not work.
-
 ### Table of contents
 
 - [Home](..#readme)

--- a/5-multi-gpu-and-node/run_ddp_srun.sh
+++ b/5-multi-gpu-and-node/run_ddp_srun.sh
@@ -20,7 +20,7 @@ export MIOPEN_CUSTOM_CACHE_DIR=$MIOPEN_DIR/cache
 export MIOPEN_USER_DB=$MIOPEN_DIR/config
 
 # choose container
-SIF=/appl/local/laifs/containers/lumi-multitorch-u24r64f21m43t29-20260225_144743/lumi-multitorch-full-u24r64f21m43t29-20260225_144743.sif
+SIF=/appl/local/laifs/containers/lumi-multitorch-u24r70f21m50t210-20260415_130625/lumi-multitorch-full-u24r70f21m50t210-20260415_130625.sif
 
 # Tell RCCL to use Slingshot interfaces and GPU RDMA
 export NCCL_SOCKET_IFNAME=hsn0,hsn1,hsn2,hsn3
@@ -34,6 +34,4 @@ export LOCAL_WORLD_SIZE=$SLURM_GPUS_PER_NODE
 # Set up the CPU bind masks
 CPU_BIND_MASKS="0x00fe000000000000,0xfe00000000000000,0x0000000000fe0000,0x00000000fe000000,0x00000000000000fe,0x000000000000fe00,0x000000fe00000000,0x0000fe0000000000"
 
-export SINGULARITYENV_PREPEND_PATH=/user-software/bin # gives access to packages inside the container
-
-srun --cpu-bind=v,mask_cpu=$CPU_BIND_MASKS singularity run -B ../resources/ai-guide-env.sqsh:/user-software:image-src=/ $SIF bash -c "export RANK=\$SLURM_PROCID && export LOCAL_RANK=\$SLURM_LOCALID && python ddp_visiontransformer.py"
+srun --cpu-bind=v,mask_cpu=$CPU_BIND_MASKS singularity run $SIF bash -c "export RANK=\$SLURM_PROCID && export LOCAL_RANK=\$SLURM_LOCALID && python ddp_visiontransformer.py"

--- a/5-multi-gpu-and-node/run_ddp_srun.sh
+++ b/5-multi-gpu-and-node/run_ddp_srun.sh
@@ -4,7 +4,7 @@
 #SBATCH --nodes=1
 #SBATCH --gpus-per-node=8
 #SBATCH --time=1:00:00
-
+#SBATCH --output=slurm-%x-%j.out
 #SBATCH --ntasks-per-node=8
 #SBATCH --cpus-per-task=7
 #SBATCH --mem-per-gpu=60G
@@ -19,17 +19,13 @@ MIOPEN_DIR=$(mktemp -d)
 export MIOPEN_CUSTOM_CACHE_DIR=$MIOPEN_DIR/cache
 export MIOPEN_USER_DB=$MIOPEN_DIR/config
 
-# Set your huggingface cache to scratch to avoid saving to home directory
-# See https://huggingface.co/docs/huggingface_hub/en/package_reference/environment_variables
-export HF_HUB_CACHE="/scratch/${SLURM_JOB_ACCOUNT}/${USER}/hfcache"
-mkdir -p "$HF_HUB_CACHE"
+# Set your TORCH_HOME cache to scratch to avoid saving to home directory
+# https://docs.pytorch.org/docs/2.11/hub.html#where-are-my-downloaded-models-saved
+export TORCH_HOME="/scratch/${SLURM_JOB_ACCOUNT}/${USER}/torch_home"
+mkdir -p "$TORCH_HOME"
 
 # choose container
 SIF=/appl/local/laifs/containers/lumi-multitorch-u24r70f21m50t210-20260415_130625/lumi-multitorch-full-u24r70f21m50t210-20260415_130625.sif
-
-# Tell RCCL to use Slingshot interfaces and GPU RDMA
-export NCCL_SOCKET_IFNAME=hsn0,hsn1,hsn2,hsn3
-export NCCL_NET_GDR_LEVEL=PHB
 
 export MASTER_ADDR=$(scontrol show hostnames $SLURM_JOB_NODELIST | head -n 1)
 export MASTER_PORT="1${SLURM_JOB_ID:0-4}" # set port based on SLURM_JOB_ID to avoid conflicts

--- a/5-multi-gpu-and-node/run_ddp_srun.sh
+++ b/5-multi-gpu-and-node/run_ddp_srun.sh
@@ -19,6 +19,11 @@ MIOPEN_DIR=$(mktemp -d)
 export MIOPEN_CUSTOM_CACHE_DIR=$MIOPEN_DIR/cache
 export MIOPEN_USER_DB=$MIOPEN_DIR/config
 
+# Set your huggingface cache to scratch to avoid saving to home directory
+# See https://huggingface.co/docs/huggingface_hub/en/package_reference/environment_variables
+export HF_HUB_CACHE="/scratch/${SLURM_JOB_ACCOUNT}/${USER}/hfcache"
+mkdir -p "$HF_HUB_CACHE"
+
 # choose container
 SIF=/appl/local/laifs/containers/lumi-multitorch-u24r70f21m50t210-20260415_130625/lumi-multitorch-full-u24r70f21m50t210-20260415_130625.sif
 

--- a/5-multi-gpu-and-node/run_ddp_srun_4.sh
+++ b/5-multi-gpu-and-node/run_ddp_srun_4.sh
@@ -20,7 +20,7 @@ export MIOPEN_CUSTOM_CACHE_DIR=$MIOPEN_DIR/cache
 export MIOPEN_USER_DB=$MIOPEN_DIR/config
 
 # choose container
-SIF=/appl/local/laifs/containers/lumi-multitorch-u24r64f21m43t29-20260225_144743/lumi-multitorch-full-u24r64f21m43t29-20260225_144743.sif
+SIF=/appl/local/laifs/containers/lumi-multitorch-u24r70f21m50t210-20260415_130625/lumi-multitorch-full-u24r70f21m50t210-20260415_130625.sif
 
 # Tell RCCL to use Slingshot interfaces and GPU RDMA
 export NCCL_SOCKET_IFNAME=hsn0,hsn1,hsn2,hsn3
@@ -34,6 +34,4 @@ export LOCAL_WORLD_SIZE=$SLURM_GPUS_PER_NODE
 # Set up the CPU bind masks
 CPU_BIND_MASKS="0x00fe000000000000,0xfe00000000000000,0x0000000000fe0000,0x00000000fe000000,0x00000000000000fe,0x000000000000fe00,0x000000fe00000000,0x0000fe0000000000"
 
-export SINGULARITYENV_PREPEND_PATH=/user-software/bin # gives access to packages inside the container
-
-srun --cpu-bind=v,mask_cpu=$CPU_BIND_MASKS singularity run -B ../resources/ai-guide-env.sqsh:/user-software:image-src=/ $SIF bash -c "export RANK=\$SLURM_PROCID && export LOCAL_RANK=\$SLURM_LOCALID && python ddp_visiontransformer.py"
+srun --cpu-bind=v,mask_cpu=$CPU_BIND_MASKS singularity run $SIF bash -c "export RANK=\$SLURM_PROCID && export LOCAL_RANK=\$SLURM_LOCALID && python ddp_visiontransformer.py"

--- a/5-multi-gpu-and-node/run_ddp_srun_4.sh
+++ b/5-multi-gpu-and-node/run_ddp_srun_4.sh
@@ -19,6 +19,12 @@ MIOPEN_DIR=$(mktemp -d)
 export MIOPEN_CUSTOM_CACHE_DIR=$MIOPEN_DIR/cache
 export MIOPEN_USER_DB=$MIOPEN_DIR/config
 
+# Set your huggingface cache to scratch to avoid saving to home directory
+# See https://huggingface.co/docs/huggingface_hub/en/package_reference/environment_variables
+export HF_HUB_CACHE="/scratch/${SLURM_JOB_ACCOUNT}/${USER}/hfcache"
+mkdir -p "$HF_HUB_CACHE"
+
+
 # choose container
 SIF=/appl/local/laifs/containers/lumi-multitorch-u24r70f21m50t210-20260415_130625/lumi-multitorch-full-u24r70f21m50t210-20260415_130625.sif
 

--- a/5-multi-gpu-and-node/run_ddp_srun_4.sh
+++ b/5-multi-gpu-and-node/run_ddp_srun_4.sh
@@ -4,7 +4,7 @@
 #SBATCH --nodes=4
 #SBATCH --gpus-per-node=8
 #SBATCH --time=1:00:00
-
+#SBATCH --output=slurm-%x-%j.out
 #SBATCH --ntasks-per-node=8
 #SBATCH --cpus-per-task=7
 #SBATCH --mem-per-gpu=60G
@@ -19,18 +19,14 @@ MIOPEN_DIR=$(mktemp -d)
 export MIOPEN_CUSTOM_CACHE_DIR=$MIOPEN_DIR/cache
 export MIOPEN_USER_DB=$MIOPEN_DIR/config
 
-# Set your huggingface cache to scratch to avoid saving to home directory
-# See https://huggingface.co/docs/huggingface_hub/en/package_reference/environment_variables
-export HF_HUB_CACHE="/scratch/${SLURM_JOB_ACCOUNT}/${USER}/hfcache"
-mkdir -p "$HF_HUB_CACHE"
+# Set your TORCH_HOME cache to scratch to avoid saving to home directory
+# https://docs.pytorch.org/docs/2.11/hub.html#where-are-my-downloaded-models-saved
+export TORCH_HOME="/scratch/${SLURM_JOB_ACCOUNT}/${USER}/torch_home"
+mkdir -p "$TORCH_HOME"
 
 
 # choose container
 SIF=/appl/local/laifs/containers/lumi-multitorch-u24r70f21m50t210-20260415_130625/lumi-multitorch-full-u24r70f21m50t210-20260415_130625.sif
-
-# Tell RCCL to use Slingshot interfaces and GPU RDMA
-export NCCL_SOCKET_IFNAME=hsn0,hsn1,hsn2,hsn3
-export NCCL_NET_GDR_LEVEL=PHB
 
 export MASTER_ADDR=$(scontrol show hostnames $SLURM_JOB_NODELIST | head -n 1)
 export MASTER_PORT="1${SLURM_JOB_ID:0-4}" # set port based on SLURM_JOB_ID to avoid conflicts

--- a/5-multi-gpu-and-node/run_ddp_torchrun.sh
+++ b/5-multi-gpu-and-node/run_ddp_torchrun.sh
@@ -21,12 +21,10 @@ export MIOPEN_CUSTOM_CACHE_DIR=$MIOPEN_DIR/cache
 export MIOPEN_USER_DB=$MIOPEN_DIR/config
 
 # choose container
-SIF=/appl/local/laifs/containers/lumi-multitorch-u24r64f21m43t29-20260225_144743/lumi-multitorch-full-u24r64f21m43t29-20260225_144743.sif
+SIF=/appl/local/laifs/containers/lumi-multitorch-u24r70f21m50t210-20260415_130625/lumi-multitorch-full-u24r70f21m50t210-20260415_130625.sif
 
 # Tell RCCL to use Slingshot interfaces and GPU RDMA
 export NCCL_SOCKET_IFNAME=hsn0,hsn1,hsn2,hsn3
 export NCCL_NET_GDR_LEVEL=PHB
 
-export SINGULARITYENV_PREPEND_PATH=/user-software/bin # gives access to packages inside the container
-
-srun singularity run -B ../resources/ai-guide-env.sqsh:/user-software:image-src=/ $SIF bash -c 'python -m torch.distributed.run --standalone --nnodes=1 --nproc_per_node=8 ddp_visiontransformer.py'
+srun singularity run $SIF bash -c 'python -m torch.distributed.run --standalone --nnodes=1 --nproc_per_node=8 ddp_visiontransformer.py'

--- a/5-multi-gpu-and-node/run_ddp_torchrun.sh
+++ b/5-multi-gpu-and-node/run_ddp_torchrun.sh
@@ -4,7 +4,7 @@
 #SBATCH --nodes=1
 #SBATCH --gpus-per-node=8
 #SBATCH --time=1:00:00
-
+#SBATCH --output=slurm-%x-%j.out
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=56
 #SBATCH --mem=480G
@@ -20,16 +20,13 @@ MIOPEN_DIR=$(mktemp -d)
 export MIOPEN_CUSTOM_CACHE_DIR=$MIOPEN_DIR/cache
 export MIOPEN_USER_DB=$MIOPEN_DIR/config
 
-# Set your huggingface cache to scratch to avoid saving to home directory
-# See https://huggingface.co/docs/huggingface_hub/en/package_reference/environment_variables
-export HF_HUB_CACHE="/scratch/${SLURM_JOB_ACCOUNT}/${USER}/hfcache"
-mkdir -p "$HF_HUB_CACHE"
+# Set your TORCH_HOME cache to scratch to avoid saving to home directory
+# https://docs.pytorch.org/docs/2.11/hub.html#where-are-my-downloaded-models-saved
+export TORCH_HOME="/scratch/${SLURM_JOB_ACCOUNT}/${USER}/torch_home"
+mkdir -p "$TORCH_HOME"
 
 # choose container
 SIF=/appl/local/laifs/containers/lumi-multitorch-u24r70f21m50t210-20260415_130625/lumi-multitorch-full-u24r70f21m50t210-20260415_130625.sif
 
-# Tell RCCL to use Slingshot interfaces and GPU RDMA
-export NCCL_SOCKET_IFNAME=hsn0,hsn1,hsn2,hsn3
-export NCCL_NET_GDR_LEVEL=PHB
 
 srun singularity run $SIF bash -c 'python -m torch.distributed.run --standalone --nnodes=1 --nproc_per_node=8 ddp_visiontransformer.py'

--- a/5-multi-gpu-and-node/run_ddp_torchrun.sh
+++ b/5-multi-gpu-and-node/run_ddp_torchrun.sh
@@ -20,6 +20,11 @@ MIOPEN_DIR=$(mktemp -d)
 export MIOPEN_CUSTOM_CACHE_DIR=$MIOPEN_DIR/cache
 export MIOPEN_USER_DB=$MIOPEN_DIR/config
 
+# Set your huggingface cache to scratch to avoid saving to home directory
+# See https://huggingface.co/docs/huggingface_hub/en/package_reference/environment_variables
+export HF_HUB_CACHE="/scratch/${SLURM_JOB_ACCOUNT}/${USER}/hfcache"
+mkdir -p "$HF_HUB_CACHE"
+
 # choose container
 SIF=/appl/local/laifs/containers/lumi-multitorch-u24r70f21m50t210-20260415_130625/lumi-multitorch-full-u24r70f21m50t210-20260415_130625.sif
 

--- a/5-multi-gpu-and-node/run_ddp_torchrun_4.sh
+++ b/5-multi-gpu-and-node/run_ddp_torchrun_4.sh
@@ -20,7 +20,7 @@ export MIOPEN_CUSTOM_CACHE_DIR=$MIOPEN_DIR/cache
 export MIOPEN_USER_DB=$MIOPEN_DIR/config
 
 # choose container
-SIF=/appl/local/laifs/containers/lumi-multitorch-u24r64f21m43t29-20260225_144743/lumi-multitorch-full-u24r64f21m43t29-20260225_144743.sif
+SIF=/appl/local/laifs/containers/lumi-multitorch-u24r70f21m50t210-20260415_130625/lumi-multitorch-full-u24r70f21m50t210-20260415_130625.sif
 
 # Tell RCCL to use Slingshot interfaces and GPU RDMA
 export NCCL_SOCKET_IFNAME=hsn0,hsn1,hsn2,hsn3
@@ -29,6 +29,4 @@ export NCCL_NET_GDR_LEVEL=PHB
 export MASTER_ADDR=$(scontrol show hostnames $SLURM_JOB_NODELIST | head -n 1)
 export MASTER_PORT="1${SLURM_JOB_ID:0-4}" # set port based on SLURM_JOB_ID to avoid conflicts
 
-export SINGULARITYENV_PREPEND_PATH=/user-software/bin # gives access to packages inside the container
-
-srun singularity run -B ../resources/ai-guide-env.sqsh:/user-software:image-src=/ $SIF bash -c 'python -m torch.distributed.run --nnodes=$SLURM_JOB_NUM_NODES --nproc_per_node=8 --rdzv_id=\$SLURM_JOB_ID --rdzv_backend=c10d --rdzv_endpoint="$MASTER_ADDR:$MASTER_PORT" ddp_visiontransformer.py'
+srun singularity run $SIF bash -c 'python -m torch.distributed.run --nnodes=$SLURM_JOB_NUM_NODES --nproc_per_node=8 --rdzv_id=\$SLURM_JOB_ID --rdzv_backend=c10d --rdzv_endpoint="$MASTER_ADDR:$MASTER_PORT" ddp_visiontransformer.py'

--- a/5-multi-gpu-and-node/run_ddp_torchrun_4.sh
+++ b/5-multi-gpu-and-node/run_ddp_torchrun_4.sh
@@ -4,7 +4,7 @@
 #SBATCH --nodes=4
 #SBATCH --gpus-per-node=8
 #SBATCH --time=1:00:00
-
+#SBATCH --output=slurm-%x-%j.out
 #SBATCH --tasks-per-node=1
 #SBATCH --cpus-per-task=56
 #SBATCH --mem=480G
@@ -19,17 +19,13 @@ MIOPEN_DIR=$(mktemp -d)
 export MIOPEN_CUSTOM_CACHE_DIR=$MIOPEN_DIR/cache
 export MIOPEN_USER_DB=$MIOPEN_DIR/config
 
-# Set your huggingface cache to scratch to avoid saving to home directory
-# See https://huggingface.co/docs/huggingface_hub/en/package_reference/environment_variables
-export HF_HUB_CACHE="/scratch/${SLURM_JOB_ACCOUNT}/${USER}/hfcache"
-mkdir -p "$HF_HUB_CACHE"
+# Set your TORCH_HOME cache to scratch to avoid saving to home directory
+# https://docs.pytorch.org/docs/2.11/hub.html#where-are-my-downloaded-models-saved
+export TORCH_HOME="/scratch/${SLURM_JOB_ACCOUNT}/${USER}/torch_home"
+mkdir -p "$TORCH_HOME"
 
 # choose container
 SIF=/appl/local/laifs/containers/lumi-multitorch-u24r70f21m50t210-20260415_130625/lumi-multitorch-full-u24r70f21m50t210-20260415_130625.sif
-
-# Tell RCCL to use Slingshot interfaces and GPU RDMA
-export NCCL_SOCKET_IFNAME=hsn0,hsn1,hsn2,hsn3
-export NCCL_NET_GDR_LEVEL=PHB
 
 export MASTER_ADDR=$(scontrol show hostnames $SLURM_JOB_NODELIST | head -n 1)
 export MASTER_PORT="1${SLURM_JOB_ID:0-4}" # set port based on SLURM_JOB_ID to avoid conflicts

--- a/5-multi-gpu-and-node/run_ddp_torchrun_4.sh
+++ b/5-multi-gpu-and-node/run_ddp_torchrun_4.sh
@@ -19,6 +19,11 @@ MIOPEN_DIR=$(mktemp -d)
 export MIOPEN_CUSTOM_CACHE_DIR=$MIOPEN_DIR/cache
 export MIOPEN_USER_DB=$MIOPEN_DIR/config
 
+# Set your huggingface cache to scratch to avoid saving to home directory
+# See https://huggingface.co/docs/huggingface_hub/en/package_reference/environment_variables
+export HF_HUB_CACHE="/scratch/${SLURM_JOB_ACCOUNT}/${USER}/hfcache"
+mkdir -p "$HF_HUB_CACHE"
+
 # choose container
 SIF=/appl/local/laifs/containers/lumi-multitorch-u24r70f21m50t210-20260415_130625/lumi-multitorch-full-u24r70f21m50t210-20260415_130625.sif
 

--- a/5-multi-gpu-and-node/run_ds_srun.sh
+++ b/5-multi-gpu-and-node/run_ds_srun.sh
@@ -20,7 +20,7 @@ export MIOPEN_CUSTOM_CACHE_DIR=$MIOPEN_DIR/cache
 export MIOPEN_USER_DB=$MIOPEN_DIR/config
 
 # choose container
-SIF=/appl/local/laifs/containers/lumi-multitorch-u24r64f21m43t29-20260225_144743/lumi-multitorch-full-u24r64f21m43t29-20260225_144743.sif
+SIF=/appl/local/laifs/containers/lumi-multitorch-u24r70f21m50t210-20260415_130625/lumi-multitorch-full-u24r70f21m50t210-20260415_130625.sif
 
 # Tell RCCL to use Slingshot interfaces and GPU RDMA
 export NCCL_SOCKET_IFNAME=hsn0,hsn1,hsn2,hsn3
@@ -34,7 +34,5 @@ export LOCAL_WORLD_SIZE=$SLURM_GPUS_PER_NODE
 # Set up the CPU bind masks
 CPU_BIND_MASKS="0x00fe000000000000,0xfe00000000000000,0x0000000000fe0000,0x00000000fe000000,0x00000000000000fe,0x000000000000fe00,0x000000fe00000000,0x0000fe0000000000"
 
-export SINGULARITYENV_PREPEND_PATH=/user-software/bin # gives access to packages inside the container
-
-srun --cpu-bind=v,mask_cpu=$CPU_BIND_MASKS singularity run -B ../resources/ai-guide-env.sqsh:/user-software:image-src=/ \
+srun --cpu-bind=v,mask_cpu=$CPU_BIND_MASKS singularity run \
 	$SIF bash -c 'export RANK=$SLURM_PROCID; export LOCAL_RANK=$SLURM_LOCALID; python ds_visiontransformer.py --deepspeed --deepspeed_config ds_config.json'

--- a/5-multi-gpu-and-node/run_ds_srun.sh
+++ b/5-multi-gpu-and-node/run_ds_srun.sh
@@ -4,7 +4,7 @@
 #SBATCH --nodes=1
 #SBATCH --gpus-per-node=8
 #SBATCH --time=1:00:00
-
+#SBATCH --output=slurm-%x-%j.out
 #SBATCH --ntasks-per-node=8
 #SBATCH --cpus-per-task=7
 #SBATCH --mem-per-gpu=60G
@@ -19,17 +19,13 @@ MIOPEN_DIR=$(mktemp -d)
 export MIOPEN_CUSTOM_CACHE_DIR=$MIOPEN_DIR/cache
 export MIOPEN_USER_DB=$MIOPEN_DIR/config
 
-# Set your huggingface cache to scratch to avoid saving to home directory
-# See https://huggingface.co/docs/huggingface_hub/en/package_reference/environment_variables
-export HF_HUB_CACHE="/scratch/${SLURM_JOB_ACCOUNT}/${USER}/hfcache"
-mkdir -p "$HF_HUB_CACHE"
+# Set your TORCH_HOME cache to scratch to avoid saving to home directory
+# https://docs.pytorch.org/docs/2.11/hub.html#where-are-my-downloaded-models-saved
+export TORCH_HOME="/scratch/${SLURM_JOB_ACCOUNT}/${USER}/torch_home"
+mkdir -p "$TORCH_HOME"
 
 # choose container
 SIF=/appl/local/laifs/containers/lumi-multitorch-u24r70f21m50t210-20260415_130625/lumi-multitorch-full-u24r70f21m50t210-20260415_130625.sif
-
-# Tell RCCL to use Slingshot interfaces and GPU RDMA
-export NCCL_SOCKET_IFNAME=hsn0,hsn1,hsn2,hsn3
-export NCCL_NET_GDR_LEVEL=PHB
 
 export MASTER_ADDR=$(scontrol show hostnames $SLURM_JOB_NODELIST | head -n 1)
 export MASTER_PORT="1${SLURM_JOB_ID:0-4}" # set port based on SLURM_JOB_ID to avoid conflicts

--- a/5-multi-gpu-and-node/run_ds_srun.sh
+++ b/5-multi-gpu-and-node/run_ds_srun.sh
@@ -19,6 +19,11 @@ MIOPEN_DIR=$(mktemp -d)
 export MIOPEN_CUSTOM_CACHE_DIR=$MIOPEN_DIR/cache
 export MIOPEN_USER_DB=$MIOPEN_DIR/config
 
+# Set your huggingface cache to scratch to avoid saving to home directory
+# See https://huggingface.co/docs/huggingface_hub/en/package_reference/environment_variables
+export HF_HUB_CACHE="/scratch/${SLURM_JOB_ACCOUNT}/${USER}/hfcache"
+mkdir -p "$HF_HUB_CACHE"
+
 # choose container
 SIF=/appl/local/laifs/containers/lumi-multitorch-u24r70f21m50t210-20260415_130625/lumi-multitorch-full-u24r70f21m50t210-20260415_130625.sif
 

--- a/5-multi-gpu-and-node/run_ds_srun_4.sh
+++ b/5-multi-gpu-and-node/run_ds_srun_4.sh
@@ -20,7 +20,7 @@ export MIOPEN_CUSTOM_CACHE_DIR=$MIOPEN_DIR/cache
 export MIOPEN_USER_DB=$MIOPEN_DIR/config
 
 # choose container
-SIF=/appl/local/laifs/containers/lumi-multitorch-u24r64f21m43t29-20260225_144743/lumi-multitorch-full-u24r64f21m43t29-20260225_144743.sif
+SIF=/appl/local/laifs/containers/lumi-multitorch-u24r70f21m50t210-20260415_130625/lumi-multitorch-full-u24r70f21m50t210-20260415_130625.sif
 
 # Tell RCCL to use Slingshot interfaces and GPU RDMA
 export NCCL_SOCKET_IFNAME=hsn0,hsn1,hsn2,hsn3
@@ -34,7 +34,5 @@ export LOCAL_WORLD_SIZE=$SLURM_GPUS_PER_NODE
 # Set up the CPU bind masks
 CPU_BIND_MASKS="0x00fe000000000000,0xfe00000000000000,0x0000000000fe0000,0x00000000fe000000,0x00000000000000fe,0x000000000000fe00,0x000000fe00000000,0x0000fe0000000000"
 
-export SINGULARITYENV_PREPEND_PATH=/user-software/bin # gives access to packages inside the container
-
-srun --cpu-bind=v,mask_cpu=$CPU_BIND_MASKS singularity run -B ../resources/ai-guide-env.sqsh:/user-software:image-src=/ \
+srun --cpu-bind=v,mask_cpu=$CPU_BIND_MASKS singularity run \
       	$SIF bash -c 'export RANK=$SLURM_PROCID; export LOCAL_RANK=$SLURM_LOCALID; python ds_visiontransformer.py --deepspeed --deepspeed_config ds_config.json'

--- a/5-multi-gpu-and-node/run_ds_srun_4.sh
+++ b/5-multi-gpu-and-node/run_ds_srun_4.sh
@@ -19,6 +19,11 @@ MIOPEN_DIR=$(mktemp -d)
 export MIOPEN_CUSTOM_CACHE_DIR=$MIOPEN_DIR/cache
 export MIOPEN_USER_DB=$MIOPEN_DIR/config
 
+# Set your huggingface cache to scratch to avoid saving to home directory
+# See https://huggingface.co/docs/huggingface_hub/en/package_reference/environment_variables
+export HF_HUB_CACHE="/scratch/${SLURM_JOB_ACCOUNT}/${USER}/hfcache"
+mkdir -p "$HF_HUB_CACHE"
+
 # choose container
 SIF=/appl/local/laifs/containers/lumi-multitorch-u24r70f21m50t210-20260415_130625/lumi-multitorch-full-u24r70f21m50t210-20260415_130625.sif
 

--- a/5-multi-gpu-and-node/run_ds_srun_4.sh
+++ b/5-multi-gpu-and-node/run_ds_srun_4.sh
@@ -4,7 +4,7 @@
 #SBATCH --nodes=4
 #SBATCH --gpus-per-node=8
 #SBATCH --time=1:00:00
-
+#SBATCH --output=slurm-%x-%j.out
 #SBATCH --ntasks-per-node=8
 #SBATCH --cpus-per-task=7
 #SBATCH --mem-per-gpu=60G
@@ -19,17 +19,13 @@ MIOPEN_DIR=$(mktemp -d)
 export MIOPEN_CUSTOM_CACHE_DIR=$MIOPEN_DIR/cache
 export MIOPEN_USER_DB=$MIOPEN_DIR/config
 
-# Set your huggingface cache to scratch to avoid saving to home directory
-# See https://huggingface.co/docs/huggingface_hub/en/package_reference/environment_variables
-export HF_HUB_CACHE="/scratch/${SLURM_JOB_ACCOUNT}/${USER}/hfcache"
-mkdir -p "$HF_HUB_CACHE"
+# Set your TORCH_HOME cache to scratch to avoid saving to home directory
+# https://docs.pytorch.org/docs/2.11/hub.html#where-are-my-downloaded-models-saved
+export TORCH_HOME="/scratch/${SLURM_JOB_ACCOUNT}/${USER}/torch_home"
+mkdir -p "$TORCH_HOME"
 
 # choose container
 SIF=/appl/local/laifs/containers/lumi-multitorch-u24r70f21m50t210-20260415_130625/lumi-multitorch-full-u24r70f21m50t210-20260415_130625.sif
-
-# Tell RCCL to use Slingshot interfaces and GPU RDMA
-export NCCL_SOCKET_IFNAME=hsn0,hsn1,hsn2,hsn3
-export NCCL_NET_GDR_LEVEL=PHB
 
 export MASTER_ADDR=$(scontrol show hostnames $SLURM_JOB_NODELIST | head -n 1)
 export MASTER_PORT="1${SLURM_JOB_ID:0-4}" # set port based on SLURM_JOB_ID to avoid conflicts

--- a/5-multi-gpu-and-node/run_ds_torchrun.sh
+++ b/5-multi-gpu-and-node/run_ds_torchrun.sh
@@ -20,12 +20,10 @@ export MIOPEN_CUSTOM_CACHE_DIR=$MIOPEN_DIR/cache
 export MIOPEN_USER_DB=$MIOPEN_DIR/config
 
 # choose container
-SIF=/appl/local/laifs/containers/lumi-multitorch-u24r64f21m43t29-20260225_144743/lumi-multitorch-full-u24r64f21m43t29-20260225_144743.sif
+SIF=/appl/local/laifs/containers/lumi-multitorch-u24r70f21m50t210-20260415_130625/lumi-multitorch-full-u24r70f21m50t210-20260415_130625.sif
 
 export MASTER_ADDR=$(scontrol show hostnames $SLURM_JOB_NODELIST | head -n 1)
 export MASTER_PORT="1${SLURM_JOB_ID:0-4}" # set port based on SLURM_JOB_ID to avoid conflicts
 
-export SINGULARITYENV_PREPEND_PATH=/user-software/bin # gives access to packages inside the container
-
-srun singularity run -B ../resources/ai-guide-env.sqsh:/user-software:image-src=/ \
+srun singularity run \
 	$SIF bash -c 'python -m torch.distributed.run --nproc_per_node 8 --nnodes $SLURM_NNODES --node_rank $SLURM_PROCID --master_addr $MASTER_ADDR --master_port $MASTER_PORT ds_visiontransformer.py --deepspeed --deepspeed_config ds_config.json'

--- a/5-multi-gpu-and-node/run_ds_torchrun.sh
+++ b/5-multi-gpu-and-node/run_ds_torchrun.sh
@@ -4,7 +4,7 @@
 #SBATCH --nodes=1
 #SBATCH --gpus-per-node=8
 #SBATCH --time=1:00:00
-
+#SBATCH --output=slurm-%x-%j.out
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=56
 #SBATCH --mem=480G
@@ -19,10 +19,10 @@ MIOPEN_DIR=$(mktemp -d)
 export MIOPEN_CUSTOM_CACHE_DIR=$MIOPEN_DIR/cache
 export MIOPEN_USER_DB=$MIOPEN_DIR/config
 
-# Set your huggingface cache to scratch to avoid saving to home directory
-# See https://huggingface.co/docs/huggingface_hub/en/package_reference/environment_variables
-export HF_HUB_CACHE="/scratch/${SLURM_JOB_ACCOUNT}/${USER}/hfcache"
-mkdir -p "$HF_HUB_CACHE"
+# Set your TORCH_HOME cache to scratch to avoid saving to home directory
+# https://docs.pytorch.org/docs/2.11/hub.html#where-are-my-downloaded-models-saved
+export TORCH_HOME="/scratch/${SLURM_JOB_ACCOUNT}/${USER}/torch_home"
+mkdir -p "$TORCH_HOME"
 
 # choose container
 SIF=/appl/local/laifs/containers/lumi-multitorch-u24r70f21m50t210-20260415_130625/lumi-multitorch-full-u24r70f21m50t210-20260415_130625.sif

--- a/5-multi-gpu-and-node/run_ds_torchrun.sh
+++ b/5-multi-gpu-and-node/run_ds_torchrun.sh
@@ -19,6 +19,11 @@ MIOPEN_DIR=$(mktemp -d)
 export MIOPEN_CUSTOM_CACHE_DIR=$MIOPEN_DIR/cache
 export MIOPEN_USER_DB=$MIOPEN_DIR/config
 
+# Set your huggingface cache to scratch to avoid saving to home directory
+# See https://huggingface.co/docs/huggingface_hub/en/package_reference/environment_variables
+export HF_HUB_CACHE="/scratch/${SLURM_JOB_ACCOUNT}/${USER}/hfcache"
+mkdir -p "$HF_HUB_CACHE"
+
 # choose container
 SIF=/appl/local/laifs/containers/lumi-multitorch-u24r70f21m50t210-20260415_130625/lumi-multitorch-full-u24r70f21m50t210-20260415_130625.sif
 

--- a/5-multi-gpu-and-node/run_ds_torchrun_4.sh
+++ b/5-multi-gpu-and-node/run_ds_torchrun_4.sh
@@ -20,7 +20,7 @@ export MIOPEN_CUSTOM_CACHE_DIR=$MIOPEN_DIR/cache
 export MIOPEN_USER_DB=$MIOPEN_DIR/config
 
 # choose container
-SIF=/appl/local/laifs/containers/lumi-multitorch-u24r64f21m43t29-20260225_144743/lumi-multitorch-full-u24r64f21m43t29-20260225_144743.sif
+SIF=/appl/local/laifs/containers/lumi-multitorch-u24r70f21m50t210-20260415_130625/lumi-multitorch-full-u24r70f21m50t210-20260415_130625.sif
 
 # Tell RCCL to use Slingshot interfaces and GPU RDMA
 export NCCL_SOCKET_IFNAME=hsn0,hsn1,hsn2,hsn3
@@ -29,7 +29,5 @@ export NCCL_NET_GDR_LEVEL=PHB
 export MASTER_ADDR=$(scontrol show hostnames $SLURM_JOB_NODELIST | head -n 1)
 export MASTER_PORT="1${SLURM_JOB_ID:0-4}" # set port based on SLURM_JOB_ID to avoid conflicts
 
-export SINGULARITYENV_PREPEND_PATH=/user-software/bin # gives access to packages inside the container
-
-srun singularity run -B ../resources/ai-guide-env.sqsh:/user-software:image-src=/ \
+srun singularity run \
 	$SIF bash -c 'python -m torch.distributed.run --nnodes=$SLURM_JOB_NUM_NODES --nproc_per_node=8 --node_rank $SLURM_PROCID --rdzv_id=\$SLURM_JOB_ID --rdzv_backend=c10d --rdzv_endpoint="$MASTER_ADDR:$MASTER_PORT" ds_visiontransformer.py --deepspeed --deepspeed_config ds_config.json'

--- a/5-multi-gpu-and-node/run_ds_torchrun_4.sh
+++ b/5-multi-gpu-and-node/run_ds_torchrun_4.sh
@@ -4,7 +4,7 @@
 #SBATCH --nodes=4
 #SBATCH --gpus-per-node=8
 #SBATCH --time=1:00:00
-
+#SBATCH --output=slurm-%x-%j.out
 #SBATCH --tasks-per-node=1
 #SBATCH --cpus-per-task=56
 #SBATCH --mem=480G
@@ -19,17 +19,13 @@ MIOPEN_DIR=$(mktemp -d)
 export MIOPEN_CUSTOM_CACHE_DIR=$MIOPEN_DIR/cache
 export MIOPEN_USER_DB=$MIOPEN_DIR/config
 
-# Set your huggingface cache to scratch to avoid saving to home directory
-# See https://huggingface.co/docs/huggingface_hub/en/package_reference/environment_variables
-export HF_HUB_CACHE="/scratch/${SLURM_JOB_ACCOUNT}/${USER}/hfcache"
-mkdir -p "$HF_HUB_CACHE"
+# Set your TORCH_HOME cache to scratch to avoid saving to home directory
+# https://docs.pytorch.org/docs/2.11/hub.html#where-are-my-downloaded-models-saved
+export TORCH_HOME="/scratch/${SLURM_JOB_ACCOUNT}/${USER}/torch_home"
+mkdir -p "$TORCH_HOME"
 
 # choose container
 SIF=/appl/local/laifs/containers/lumi-multitorch-u24r70f21m50t210-20260415_130625/lumi-multitorch-full-u24r70f21m50t210-20260415_130625.sif
-
-# Tell RCCL to use Slingshot interfaces and GPU RDMA
-export NCCL_SOCKET_IFNAME=hsn0,hsn1,hsn2,hsn3
-export NCCL_NET_GDR_LEVEL=PHB
 
 export MASTER_ADDR=$(scontrol show hostnames $SLURM_JOB_NODELIST | head -n 1)
 export MASTER_PORT="1${SLURM_JOB_ID:0-4}" # set port based on SLURM_JOB_ID to avoid conflicts

--- a/5-multi-gpu-and-node/run_ds_torchrun_4.sh
+++ b/5-multi-gpu-and-node/run_ds_torchrun_4.sh
@@ -19,6 +19,11 @@ MIOPEN_DIR=$(mktemp -d)
 export MIOPEN_CUSTOM_CACHE_DIR=$MIOPEN_DIR/cache
 export MIOPEN_USER_DB=$MIOPEN_DIR/config
 
+# Set your huggingface cache to scratch to avoid saving to home directory
+# See https://huggingface.co/docs/huggingface_hub/en/package_reference/environment_variables
+export HF_HUB_CACHE="/scratch/${SLURM_JOB_ACCOUNT}/${USER}/hfcache"
+mkdir -p "$HF_HUB_CACHE"
+
 # choose container
 SIF=/appl/local/laifs/containers/lumi-multitorch-u24r70f21m50t210-20260415_130625/lumi-multitorch-full-u24r70f21m50t210-20260415_130625.sif
 

--- a/6-monitoring-and-profiling/run.sh
+++ b/6-monitoring-and-profiling/run.sh
@@ -18,7 +18,7 @@ export MIOPEN_CUSTOM_CACHE_DIR=$MIOPEN_DIR/cache
 export MIOPEN_USER_DB=$MIOPEN_DIR/config
 
 # choose container
-SIF=/appl/local/laifs/containers/lumi-multitorch-u24r64f21m43t29-20260225_144743/lumi-multitorch-full-u24r64f21m43t29-20260225_144743.sif
+SIF=/appl/local/laifs/containers/lumi-multitorch-u24r70f21m50t210-20260415_130625/lumi-multitorch-full-u24r70f21m50t210-20260415_130625.sif
 
 export SINGULARITYENV_PREPEND_PATH=/user-software/bin # gives access to packages inside the container
-singularity run -B ../resources/ai-guide-env.sqsh:/user-software:image-src=/ $SIF bash -c 'python visiontransformer_profiled.py'
+singularity run $SIF bash -c 'python visiontransformer_profiled.py'

--- a/6-monitoring-and-profiling/run.sh
+++ b/6-monitoring-and-profiling/run.sh
@@ -17,6 +17,11 @@ MIOPEN_DIR=$(mktemp -d)
 export MIOPEN_CUSTOM_CACHE_DIR=$MIOPEN_DIR/cache
 export MIOPEN_USER_DB=$MIOPEN_DIR/config
 
+# Set your huggingface cache to scratch to avoid saving to home directory
+# See https://huggingface.co/docs/huggingface_hub/en/package_reference/environment_variables
+export HF_HUB_CACHE="/scratch/${SLURM_JOB_ACCOUNT}/${USER}/hfcache"
+mkdir -p "$HF_HUB_CACHE"
+
 # choose container
 SIF=/appl/local/laifs/containers/lumi-multitorch-u24r70f21m50t210-20260415_130625/lumi-multitorch-full-u24r70f21m50t210-20260415_130625.sif
 

--- a/6-monitoring-and-profiling/run.sh
+++ b/6-monitoring-and-profiling/run.sh
@@ -17,10 +17,10 @@ MIOPEN_DIR=$(mktemp -d)
 export MIOPEN_CUSTOM_CACHE_DIR=$MIOPEN_DIR/cache
 export MIOPEN_USER_DB=$MIOPEN_DIR/config
 
-# Set your huggingface cache to scratch to avoid saving to home directory
-# See https://huggingface.co/docs/huggingface_hub/en/package_reference/environment_variables
-export HF_HUB_CACHE="/scratch/${SLURM_JOB_ACCOUNT}/${USER}/hfcache"
-mkdir -p "$HF_HUB_CACHE"
+# Set your TORCH_HOME cache to scratch to avoid saving to home directory
+# https://docs.pytorch.org/docs/2.11/hub.html#where-are-my-downloaded-models-saved
+export TORCH_HOME="/scratch/${SLURM_JOB_ACCOUNT}/${USER}/torch_home"
+mkdir -p "$TORCH_HOME"
 
 # choose container
 SIF=/appl/local/laifs/containers/lumi-multitorch-u24r70f21m50t210-20260415_130625/lumi-multitorch-full-u24r70f21m50t210-20260415_130625.sif

--- a/7-TensorBoard-visualization/run_ddp_torchrun.sh
+++ b/7-TensorBoard-visualization/run_ddp_torchrun.sh
@@ -21,12 +21,10 @@ export MIOPEN_CUSTOM_CACHE_DIR=$MIOPEN_DIR/cache
 export MIOPEN_USER_DB=$MIOPEN_DIR/config
 
 # choose container
-SIF=/appl/local/laifs/containers/lumi-multitorch-u24r64f21m43t29-20260225_144743/lumi-multitorch-full-u24r64f21m43t29-20260225_144743.sif
+SIF=/appl/local/laifs/containers/lumi-multitorch-u24r70f21m50t210-20260415_130625/lumi-multitorch-full-u24r70f21m50t210-20260415_130625.sif
 
 # Tell RCCL to use Slingshot interfaces and GPU RDMA
 export NCCL_SOCKET_IFNAME=hsn0,hsn1,hsn2,hsn3
 export NCCL_NET_GDR_LEVEL=PHB
 
-export SINGULARITYENV_PREPEND_PATH=/user-software/bin # gives access to packages inside the container
-
-srun singularity run -B ../resources/ai-guide-env.sqsh:/user-software:image-src=/ $SIF bash -c 'python -m torch.distributed.run --standalone --nnodes=1 --nproc_per_node=8 tensorboard_ddp_visiontransformer.py'
+srun singularity run $SIF bash -c 'python -m torch.distributed.run --standalone --nnodes=1 --nproc_per_node=8 tensorboard_ddp_visiontransformer.py'

--- a/7-TensorBoard-visualization/run_ddp_torchrun.sh
+++ b/7-TensorBoard-visualization/run_ddp_torchrun.sh
@@ -28,8 +28,4 @@ mkdir -p "$TORCH_HOME"
 # choose container
 SIF=/appl/local/laifs/containers/lumi-multitorch-u24r70f21m50t210-20260415_130625/lumi-multitorch-full-u24r70f21m50t210-20260415_130625.sif
 
-# Tell RCCL to use Slingshot interfaces and GPU RDMA
-export NCCL_SOCKET_IFNAME=hsn0,hsn1,hsn2,hsn3
-export NCCL_NET_GDR_LEVEL=PHB
-
 srun singularity run $SIF bash -c 'python -m torch.distributed.run --standalone --nnodes=1 --nproc_per_node=8 tensorboard_ddp_visiontransformer.py'

--- a/7-TensorBoard-visualization/run_ddp_torchrun.sh
+++ b/7-TensorBoard-visualization/run_ddp_torchrun.sh
@@ -20,10 +20,10 @@ MIOPEN_DIR=$(mktemp -d)
 export MIOPEN_CUSTOM_CACHE_DIR=$MIOPEN_DIR/cache
 export MIOPEN_USER_DB=$MIOPEN_DIR/config
 
-# Set your huggingface cache to scratch to avoid saving to home directory
-# See https://huggingface.co/docs/huggingface_hub/en/package_reference/environment_variables
-export HF_HUB_CACHE="/scratch/${SLURM_JOB_ACCOUNT}/${USER}/hfcache"
-mkdir -p "$HF_HUB_CACHE"
+# Set your TORCH_HOME cache to scratch to avoid saving to home directory
+# https://docs.pytorch.org/docs/2.11/hub.html#where-are-my-downloaded-models-saved
+export TORCH_HOME="/scratch/${SLURM_JOB_ACCOUNT}/${USER}/torch_home"
+mkdir -p "$TORCH_HOME"
 
 # choose container
 SIF=/appl/local/laifs/containers/lumi-multitorch-u24r70f21m50t210-20260415_130625/lumi-multitorch-full-u24r70f21m50t210-20260415_130625.sif

--- a/7-TensorBoard-visualization/run_ddp_torchrun.sh
+++ b/7-TensorBoard-visualization/run_ddp_torchrun.sh
@@ -20,6 +20,11 @@ MIOPEN_DIR=$(mktemp -d)
 export MIOPEN_CUSTOM_CACHE_DIR=$MIOPEN_DIR/cache
 export MIOPEN_USER_DB=$MIOPEN_DIR/config
 
+# Set your huggingface cache to scratch to avoid saving to home directory
+# See https://huggingface.co/docs/huggingface_hub/en/package_reference/environment_variables
+export HF_HUB_CACHE="/scratch/${SLURM_JOB_ACCOUNT}/${USER}/hfcache"
+mkdir -p "$HF_HUB_CACHE"
+
 # choose container
 SIF=/appl/local/laifs/containers/lumi-multitorch-u24r70f21m50t210-20260415_130625/lumi-multitorch-full-u24r70f21m50t210-20260415_130625.sif
 

--- a/8-MLflow-visualization/README.md
+++ b/8-MLflow-visualization/README.md
@@ -3,7 +3,7 @@
 > [!NOTE]  
 > If you wish to run the included examples on LUMI, have a look at the [quickstart](https://github.com/Lumi-supercomputer/LUMI-AI-Guide/tree/main/1-quickstart#readme) chapter for instructions on how to set up the required environment.
 
-[MLflow](https://www.mlflow.org/) is an open source tool for tracking experiments and models in machine learning projects. MLflow can be easily installed with `pip install mlflow==2.22.*` (currently, LUMI webinterface requires `mlflow==2.22.*` to read the created file). Adapting your code to use MLflow requires minimal modification, and the results can be easily displayed using the web interface.
+__[MLflow](https://www.mlflow.org/)__ is an open source tool for tracking experiments and models in machine learning projects. MLflow 3.11.1 is already available in the lumi-multitorch-full container as of the April 2026 release (ROCm 7.0) and later. Adapting your code to use MLflow requires minimal modification, and the results can be easily displayed using the web interface.
 
 ## Collecting logs
 

--- a/8-MLflow-visualization/README.md
+++ b/8-MLflow-visualization/README.md
@@ -3,7 +3,7 @@
 > [!NOTE]  
 > If you wish to run the included examples on LUMI, have a look at the [quickstart](https://github.com/Lumi-supercomputer/LUMI-AI-Guide/tree/main/1-quickstart#readme) chapter for instructions on how to set up the required environment.
 
-__[MLflow](https://www.mlflow.org/)__ is an open source tool for tracking experiments and models in machine learning projects. MLflow 3.11.1 is already available in the lumi-multitorch-full container as of the April 2026 release (ROCm 7.0) and later. Adapting your code to use MLflow requires minimal modification, and the results can be easily displayed using the web interface.
+[MLflow](https://www.mlflow.org/) is an open source tool for tracking experiments and models in machine learning projects. MLflow can be easily installed with `pip install mlflow==2.22.*` (currently, LUMI webinterface requires `mlflow==2.22.*` to read the created file). Adapting your code to use MLflow requires minimal modification, and the results can be easily displayed using the web interface.
 
 ## Collecting logs
 

--- a/8-MLflow-visualization/run_ddp_torchrun.sh
+++ b/8-MLflow-visualization/run_ddp_torchrun.sh
@@ -19,10 +19,10 @@ MIOPEN_DIR=$(mktemp -d)
 export MIOPEN_CUSTOM_CACHE_DIR=$MIOPEN_DIR/cache
 export MIOPEN_USER_DB=$MIOPEN_DIR/config
 
-# Set your huggingface cache to scratch to avoid saving to home directory
-# See https://huggingface.co/docs/huggingface_hub/en/package_reference/environment_variables
-export HF_HUB_CACHE="/scratch/${SLURM_JOB_ACCOUNT}/${USER}/hfcache"
-mkdir -p "$HF_HUB_CACHE"
+# Set your TORCH_HOME cache to scratch to avoid saving to home directory
+# https://docs.pytorch.org/docs/2.11/hub.html#where-are-my-downloaded-models-saved
+export TORCH_HOME="/scratch/${SLURM_JOB_ACCOUNT}/${USER}/torch_home"
+mkdir -p "$TORCH_HOME"
 
 # choose container
 SIF=/appl/local/laifs/containers/lumi-multitorch-u24r70f21m50t210-20260415_130625/lumi-multitorch-full-u24r70f21m50t210-20260415_130625.sif

--- a/8-MLflow-visualization/run_ddp_torchrun.sh
+++ b/8-MLflow-visualization/run_ddp_torchrun.sh
@@ -20,7 +20,13 @@ export MIOPEN_CUSTOM_CACHE_DIR=$MIOPEN_DIR/cache
 export MIOPEN_USER_DB=$MIOPEN_DIR/config
 
 # choose container
-SIF=/appl/local/laifs/containers/lumi-multitorch-u24r70f21m50t210-20260415_130625/lumi-multitorch-full-u24r70f21m50t210-20260415_130625.sif
+SIF=/appl/local/laifs/containers/lumi-multitorch-u24r64f21m43t29-20260225_144743/lumi-multitorch-full-u24r64f21m43t29-20260225_144743.sif
 
+# Tell RCCL to use Slingshot interfaces and GPU RDMA
+export NCCL_SOCKET_IFNAME=hsn0,hsn1,hsn2,hsn3
+export NCCL_NET_GDR_LEVEL=PHB
 
-srun singularity run $SIF bash -c 'python -m torch.distributed.run --standalone --nnodes=1 --nproc_per_node=8 mlflow_ddp_visiontransformer.py'
+export SINGULARITYENV_PREPEND_PATH=/user-software/bin # gives access to packages inside the container
+
+# need to create sqsh file with mlflow included
+srun singularity run -B ../resources/ai-guide-env.sqsh:/user-software:image-src=/ $SIF bash -c 'python -m torch.distributed.run --standalone --nnodes=1 --nproc_per_node=8 mlflow_ddp_visiontransformer.py'

--- a/8-MLflow-visualization/run_ddp_torchrun.sh
+++ b/8-MLflow-visualization/run_ddp_torchrun.sh
@@ -19,6 +19,11 @@ MIOPEN_DIR=$(mktemp -d)
 export MIOPEN_CUSTOM_CACHE_DIR=$MIOPEN_DIR/cache
 export MIOPEN_USER_DB=$MIOPEN_DIR/config
 
+# Set your huggingface cache to scratch to avoid saving to home directory
+# See https://huggingface.co/docs/huggingface_hub/en/package_reference/environment_variables
+export HF_HUB_CACHE="/scratch/${SLURM_JOB_ACCOUNT}/${USER}/hfcache"
+mkdir -p "$HF_HUB_CACHE"
+
 # choose container
 SIF=/appl/local/laifs/containers/lumi-multitorch-u24r64f21m43t29-20260225_144743/lumi-multitorch-full-u24r64f21m43t29-20260225_144743.sif
 

--- a/8-MLflow-visualization/run_ddp_torchrun.sh
+++ b/8-MLflow-visualization/run_ddp_torchrun.sh
@@ -25,13 +25,6 @@ export HF_HUB_CACHE="/scratch/${SLURM_JOB_ACCOUNT}/${USER}/hfcache"
 mkdir -p "$HF_HUB_CACHE"
 
 # choose container
-SIF=/appl/local/laifs/containers/lumi-multitorch-u24r64f21m43t29-20260225_144743/lumi-multitorch-full-u24r64f21m43t29-20260225_144743.sif
+SIF=/appl/local/laifs/containers/lumi-multitorch-u24r70f21m50t210-20260415_130625/lumi-multitorch-full-u24r70f21m50t210-20260415_130625.sif
 
-# Tell RCCL to use Slingshot interfaces and GPU RDMA
-export NCCL_SOCKET_IFNAME=hsn0,hsn1,hsn2,hsn3
-export NCCL_NET_GDR_LEVEL=PHB
-
-export SINGULARITYENV_PREPEND_PATH=/user-software/bin # gives access to packages inside the container
-
-# need to create sqsh file with mlflow included
-srun singularity run -B ../resources/ai-guide-env.sqsh:/user-software:image-src=/ $SIF bash -c 'python -m torch.distributed.run --standalone --nnodes=1 --nproc_per_node=8 mlflow_ddp_visiontransformer.py'
+srun singularity run $SIF bash -c 'python -m torch.distributed.run --standalone --nnodes=1 --nproc_per_node=8 mlflow_ddp_visiontransformer.py'

--- a/9-Wandb-visualization/run_ddp_torchrun.sh
+++ b/9-Wandb-visualization/run_ddp_torchrun.sh
@@ -21,13 +21,11 @@ export MIOPEN_CUSTOM_CACHE_DIR=$MIOPEN_DIR/cache
 export MIOPEN_USER_DB=$MIOPEN_DIR/config
 
 # choose container
-SIF=/appl/local/laifs/containers/lumi-multitorch-u24r64f21m43t29-20260225_144743/lumi-multitorch-full-u24r64f21m43t29-20260225_144743.sif
+SIF=/appl/local/laifs/containers/lumi-multitorch-u24r70f21m50t210-20260415_130625/lumi-multitorch-full-u24r70f21m50t210-20260415_130625.sif
 
 # Tell RCCL to use Slingshot interfaces and GPU RDMA
 export NCCL_SOCKET_IFNAME=hsn0,hsn1,hsn2,hsn3
 export NCCL_NET_GDR_LEVEL=PHB
 
-export SINGULARITYENV_PREPEND_PATH=/user-software/bin # gives access to packages inside the container
-
 # need to create sqsh file with mlflow included
-srun singularity run -B ../resources/ai-guide-ml-flow-env.sqsh:/user-software:image-src=/ $SIF bash -c 'python -m torch.distributed.run --standalone --nnodes=1 --nproc_per_node=8 wandb_ddp_visiontransformer.py'
+srun singularity run $SIF bash -c 'python -m torch.distributed.run --standalone --nnodes=1 --nproc_per_node=8 wandb_ddp_visiontransformer.py'

--- a/9-Wandb-visualization/run_ddp_torchrun.sh
+++ b/9-Wandb-visualization/run_ddp_torchrun.sh
@@ -20,10 +20,10 @@ MIOPEN_DIR=$(mktemp -d)
 export MIOPEN_CUSTOM_CACHE_DIR=$MIOPEN_DIR/cache
 export MIOPEN_USER_DB=$MIOPEN_DIR/config
 
-# Set your huggingface cache to scratch to avoid saving to home directory
-# See https://huggingface.co/docs/huggingface_hub/en/package_reference/environment_variables
-export HF_HUB_CACHE="/scratch/${SLURM_JOB_ACCOUNT}/${USER}/hfcache"
-mkdir -p "$HF_HUB_CACHE"
+# Set your TORCH_HOME cache to scratch to avoid saving to home directory
+# https://docs.pytorch.org/docs/2.11/hub.html#where-are-my-downloaded-models-saved
+export TORCH_HOME="/scratch/${SLURM_JOB_ACCOUNT}/${USER}/torch_home"
+mkdir -p "$TORCH_HOME"
 
 # choose container
 SIF=/appl/local/laifs/containers/lumi-multitorch-u24r70f21m50t210-20260415_130625/lumi-multitorch-full-u24r70f21m50t210-20260415_130625.sif

--- a/9-Wandb-visualization/run_ddp_torchrun.sh
+++ b/9-Wandb-visualization/run_ddp_torchrun.sh
@@ -28,9 +28,5 @@ mkdir -p "$TORCH_HOME"
 # choose container
 SIF=/appl/local/laifs/containers/lumi-multitorch-u24r70f21m50t210-20260415_130625/lumi-multitorch-full-u24r70f21m50t210-20260415_130625.sif
 
-# Tell RCCL to use Slingshot interfaces and GPU RDMA
-export NCCL_SOCKET_IFNAME=hsn0,hsn1,hsn2,hsn3
-export NCCL_NET_GDR_LEVEL=PHB
-
 # need to create sqsh file with mlflow included
 srun singularity run $SIF bash -c 'python -m torch.distributed.run --standalone --nnodes=1 --nproc_per_node=8 wandb_ddp_visiontransformer.py'

--- a/9-Wandb-visualization/run_ddp_torchrun.sh
+++ b/9-Wandb-visualization/run_ddp_torchrun.sh
@@ -20,6 +20,11 @@ MIOPEN_DIR=$(mktemp -d)
 export MIOPEN_CUSTOM_CACHE_DIR=$MIOPEN_DIR/cache
 export MIOPEN_USER_DB=$MIOPEN_DIR/config
 
+# Set your huggingface cache to scratch to avoid saving to home directory
+# See https://huggingface.co/docs/huggingface_hub/en/package_reference/environment_variables
+export HF_HUB_CACHE="/scratch/${SLURM_JOB_ACCOUNT}/${USER}/hfcache"
+mkdir -p "$HF_HUB_CACHE"
+
 # choose container
 SIF=/appl/local/laifs/containers/lumi-multitorch-u24r70f21m50t210-20260415_130625/lumi-multitorch-full-u24r70f21m50t210-20260415_130625.sif
 

--- a/resources/requirements.txt
+++ b/resources/requirements.txt
@@ -1,2 +1,0 @@
-h5py
-mlflow==2.22.* # required only for part 8

--- a/resources/requirements.txt
+++ b/resources/requirements.txt
@@ -1,1 +1,2 @@
 h5py
+mlflow==2.22.* # required only for part 8


### PR DESCRIPTION
- Use `/appl/local/laifs/containers/lumi-multitorch-u24r70f21m50t210-20260415_130625/lumi-multitorch-full-u24r70f21m50t210-20260415_130625.sif` as a container with ROCm 7.0
- This container already contains pip package `h5py` and thus we can remove the squashFS file in lessons 1, 4-9 (closes #92), we deleted the `resources/requirements.txt`
- Update to ROCm 7.0 container closes #83 as ROCm 7.0 container patches the bug with poor performance
- Added `TORCH_HOME` at `TORCH_HOME="/scratch/${SLURM_JOB_ACCOUNT}/${USER}/torch_home"` (closes #80). 
- Multi-node jobs hang when exporting `NCCL_NET_GDR_LEVEL=PHB` as mentioned by container maintainers in  https://github.com/lumi-ai-factory/laifs-container-recipes/issues/30 . Removing them seems to help without performance decreases, so I removed them (closes #94 ).
- In Chapter 5 I added the job name to the output file name to make it more understandable what is being run.